### PR TITLE
Re-enable checking out of repo prior to running action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     name: A job to check if a merged PR had tech debt and create an issue if so
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        if: github.event.pull_request.merged # We only want to track tech debt for things that get merged
       - name: Create ticket step
         uses: ./
-        if: github.event.pull_request.merged # We only want to track tech debt for things that get merged
         id: createTicket
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request enables logging in with social accounts, however introduces technical debt due to requirements on how quickly we need to ship the feature.

[DEBT_ISSUE_TITLE] EXAMPLE ISSUE - Refactor logging in with social accounts

[DEBT_ISSUE_BODY] Currently, the logic for logging in with social accounts is at the view layer in the app. It needs to be moved out into a helper class and we should utilize the ViewModel appropriately to give the View what it needs. Let's keep our views as dumb as possible for readability and maintainability.