### PR TITLE
Implement linking Issues back to their parent Pull Request

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18343,10 +18343,12 @@ function createIssue(issueTitle, issueBody) {
       const myToken = core.getInput('myToken');
       const octokit = new github.GitHub(myToken);
 
+      const prHtmlURL = context.payload.pull_request.html_url;
+
       const newIssue = await octokit.issues.create({
         ...context.repo,
         title: "[DEBT] " + issueTitle,
-        body: issueBody
+        body: issueBody + "\r\n\r\n See the [Pull Request that created this Issue](" + prHtmlURL + ")"
       });
 
       console.log("Issue created: [DEBT] " + issueTitle);

--- a/index.js
+++ b/index.js
@@ -60,10 +60,12 @@ function createIssue(issueTitle, issueBody) {
       const myToken = core.getInput('myToken');
       const octokit = new github.GitHub(myToken);
 
+      const prHtmlURL = context.payload.pull_request.html_url;
+
       const newIssue = await octokit.issues.create({
         ...context.repo,
         title: "[DEBT] " + issueTitle,
-        body: issueBody
+        body: issueBody + "\r\n\r\n See the [Pull Request that created this Issue](" + prHtmlURL + ")"
       });
 
       console.log("Issue created: [DEBT] " + issueTitle);


### PR DESCRIPTION
This pull request enables auto linking an Issue to its parent Pull Request in the OP. It doesn't introduce technical debt, but we're going to pretend it does for demonstration purposes.

[DEBT_ISSUE_TITLE] The code could be tidier

[DEBT_ISSUE_BODY] Honestly, the code could be a bit cleaner here. We'll clean it up later.